### PR TITLE
[FEATURE] Add initial docker development configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.7"
+
+services:
+  app:
+    container_name: "ranger_clubhouse_web"
+    image: "${NODE_IMG_TAG:-node:20-alpine}"
+    user: ":${NODE_GROUP_ID:-1420}"
+    ports:
+      - "${NODE_PORT:-4200}:4200"
+    environment:
+      - "API_SERVER=${API_SERVER:-http://localhost:8000}"
+    volumes:
+      - "./:/app:cached"
+    command: "npm start"
+    working_dir: "/app"
+
+networks:
+  default:
+    external: true
+    name: "${DOCKER_RANGERS_NETWORK:-ranger-clubhouse}"


### PR DESCRIPTION
## Overview

Goal is to support faster development environment provisioning with a docker & docker-compose setup.

### WIP TODO

 - [ ] Organize docker files in `docker` directory
 - [ ] Add `caddy` reverse proxy with `ims.lvh.me` domain or similar
 - [ ] Optimize Dockerfile
 - [ ] Add `README` steps for development
 - [ ] Add ability to run linters & tests from compose commands